### PR TITLE
Build: esbuild CANARY — ship esbuild artifact only in this branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build": "node build.js",
     "build:check": "node -e \"const fs=require('fs'),c=require('crypto');const a=fs.readFileSync('mgtools.user.js');const b=fs.readFileSync('dist/mgtools.user.js');const ha=c.createHash('sha256').update(a).digest('hex');const hb=c.createHash('sha256').update(b).digest('hex');if(ha!==hb){console.error('❌ Build mismatch');process.exit(1)}console.log('✅ Build matches source')\"",
     "build:esbuild": "node scripts/build-esbuild.mjs",
-    "hash": "node scripts/hash-compare.mjs"
+    "hash": "node scripts/hash-compare.mjs",
+    "preship:esbuild": "npm run build:esbuild",
+    "ship:esbuild": "node scripts/ship-from-esbuild.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/ship-from-esbuild.mjs
+++ b/scripts/ship-from-esbuild.mjs
@@ -1,0 +1,22 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+const SRC = 'dist/mgtools.esbuild.user.js';
+const DEST = 'dist/mgtools.user.js';
+
+const src = readFileSync(SRC, 'utf8');
+if (!/\/\/\s*==UserScript==[\s\S]*?==\/UserScript==/.test(src)) {
+  console.error('❌ Userscript header missing in esbuild artifact');
+  process.exit(1);
+}
+writeFileSync(DEST, src);
+
+const sha = (s) => createHash('sha256').update(s).digest('hex');
+const a = sha(src);
+const b = sha(readFileSync(DEST, 'utf8'));
+if (a !== b) {
+  console.error('❌ Copy mismatch');
+  process.exit(1);
+}
+console.log('✅ Canary ship OK — dist/mgtools.user.js now equals esbuild artifact');
+console.log('sha256:', a);


### PR DESCRIPTION
## Summary
Phase 3C: Create an isolated canary branch that ships the esbuild artifact only in this branch. Default shipping remains mirror build on all other branches.

## Implementation
- Created `scripts/ship-from-esbuild.mjs` to copy esbuild artifact to shipping path
- Added `npm run ship:esbuild` script
- On this branch ONLY, `dist/mgtools.user.js` equals the esbuild artifact
- No code rewiring beyond Phase 3B
- Userscript header preserved

## Purpose
- Isolated QA environment for testing modular artifact
- Validate all module integrations work correctly
- No risk to Live-Beta or other development branches

Labels: build, esbuild, canary (to be applied)