### PR TITLE
Build: gated flip — BUILD_STRATEGY switch (default mirror)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "build": "node build.js",
     "build:check": "node -e \"const fs=require('fs'),c=require('crypto');const a=fs.readFileSync('mgtools.user.js');const b=fs.readFileSync('dist/mgtools.user.js');const ha=c.createHash('sha256').update(a).digest('hex');const hb=c.createHash('sha256').update(b).digest('hex');if(ha!==hb){console.error('❌ Build mismatch');process.exit(1)}console.log('✅ Build matches source')\"",
     "build:esbuild": "node scripts/build-esbuild.mjs",
+    "build:mirror": "BUILD_STRATEGY=mirror node build.js",
+    "build:esb": "BUILD_STRATEGY=esbuild node build.js",
+    "build:esb:win": "set BUILD_STRATEGY=esbuild&& node build.js",
+    "build:mirror:win": "set BUILD_STRATEGY=mirror&& node build.js",
     "hash": "node scripts/hash-compare.mjs",
     "preship:esbuild": "npm run build:esbuild",
     "ship:esbuild": "node scripts/ship-from-esbuild.mjs"


### PR DESCRIPTION
## Summary
Phase 3D: Add BUILD_STRATEGY environment gate to allow selecting between mirror (default) and esbuild builds.

## Implementation
- Updated `build.js` with BUILD_STRATEGY env var (defaults to "mirror")
- Added cross-platform npm scripts: `build:mirror`, `build:esb`, `build:esb:win`, `build:mirror:win`
- Mirror remains default on all branches
- CI can opt-in to esbuild per branch by setting BUILD_STRATEGY=esbuild

## Purpose
- Safe gated rollout mechanism for esbuild
- Keep mirror as default (no breaking changes)
- Enable gradual testing in CI before full switch

Labels: build, esbuild, flip (to be applied)